### PR TITLE
ci(pre-commit): Remove `validate_manifest` hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -70,10 +70,6 @@ repos:
   - repo: meta
     hooks:
       - id: check-useless-excludes
-  - repo: https://github.com/pre-commit/pre-commit
-    rev: v2.18.1 # Keep in sync with pyproject.toml.
-    hooks:
-      - id: validate_manifest
 
   ## Python
   - repo: https://github.com/Lucas-C/pre-commit-hooks-safety

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,5 @@ build-backend = "poetry.core.masonry.api"
   python = "^3.10.4"
 
   [tool.poetry.dev-dependencies]
-  # Keep in sync with .pre-commit-config.yaml.
-  commitizen = "^2.24.0"
+  commitizen = "^2.24.0" # Keep in sync with .pre-commit-config.yaml.
   pre-commit = "^2.18.1"


### PR DESCRIPTION
This hook validates a `.pre-commit-hooks.yaml` file, which we don't have.