### PR TITLE
chore(MegaLinter): Upgrade from v5.12.0 to v5.13.0

### DIFF
--- a/.dictionary.txt
+++ b/.dictionary.txt
@@ -1,3 +1,1 @@
 Laven
-Octicons
-zstd

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@ repos:
 
   ## Python, Polyglot, Git, pre-commit
   - repo: https://github.com/ScribeMD/pre-commit-hooks
-    rev: 0.4.0
+    rev: 0.5.0
     hooks:
       - id: no-merge-commits
       - id: asdf-install

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,7 +24,7 @@ repos:
       - id: poetry-install
       - id: pre-commit-install
       - id: megalinter
-        args: &megalinter-args [--flavor, documentation, --release, v5.12.0]
+        args: &megalinter-args [--flavor, documentation, --release, v5.13.0]
       - id: megalinter-all
         args: *megalinter-args
 

--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -9,5 +9,6 @@ dictionaryDefinitions:
 dictionaries:
   - css
   - custom
+  - fullstack
   - npm
   - python


### PR DESCRIPTION
Remove "Octicons" from custom dictionary, which was added upstream. Add fullstack dictionary, and remove "zstd" from custom dictionary, which was added to the fullstack dictionary upstream.

Upgrade all pre-commit hooks to latest.

ScribeMD/pre-commit-hooks 0.4.0 --> 0.5.0