### PR TITLE
docs(README): Make badges more consistent

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # .github
 
-[![Test](https://github.com/ScribeMD/.github/workflows/Test/badge.svg)](https://github.com/ScribeMD/.github/actions/workflows/test.yaml)
-[![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=white)](https://github.com/pre-commit/pre-commit)
-[![Conventional Commits](https://img.shields.io/badge/Conventional%20Commits-1.0.0-yellow.svg?style=flat-square)](https://conventionalcommits.org)
-[![code style: prettier](https://img.shields.io/badge/code_style-prettier-ff69b4.svg?style=flat-square)](https://github.com/prettier/prettier)
+[![Test Workflow Status](https://github.com/ScribeMD/.github/workflows/Test/badge.svg)](https://github.com/ScribeMD/.github/actions/workflows/test.yaml)
+[![Git Hooks: pre-commit](https://img.shields.io/badge/pre--commit-Git_Hooks-orange?logo=precommit&logoColor=FAB040)](https://github.com/pre-commit/pre-commit)
+[![Commit Style: Conventional Commits](https://img.shields.io/badge/Conventional_Commits-Commit_Style-yellow?logo=conventionalcommits&logoColor=FE5196)](https://conventionalcommits.org)
+[![Code Style: Prettier](https://img.shields.io/badge/Prettier-Code_Style-FF69B4?logo=prettier&logoColor=F7B93E)](https://github.com/prettier/prettier)
 
 <!--TOC-->
 


### PR DESCRIPTION
- Use technology name for label and its role for message.
- Make alt text `<message>: <label>`.
- Use Title Case for labels, messages, and alt text.
- Include pre-commit, Conventional Commits, and Prettier logos from [Simple Icons](https://simpleicons.org/) in their respective badges using the logo colors recommended by Simple Icons.
- Use uppercase for all hex colors.
- Use the flat badge style for all badges to match the GitHub Actions workflow status badge.