### PR TITLE
feat(GitHub-Actions): Grant minimum needed scopes

### DIFF
--- a/workflow-templates/notify-assignee.yaml
+++ b/workflow-templates/notify-assignee.yaml
@@ -7,6 +7,8 @@ jobs:
   notify-assignee:
     name: Notify Assignee
     uses: ScribeMD/slack-templates/.github/workflows/notify-assignee.yaml@main
+    permissions:
+      contents: read
     secrets:
       SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
       SLACK_ASSIGN_CHANNEL_ID: ${{ secrets.SLACK_ASSIGN_CHANNEL_ID }}

--- a/workflow-templates/notify-reviewers.yaml
+++ b/workflow-templates/notify-reviewers.yaml
@@ -7,6 +7,8 @@ jobs:
   notify-reviewers:
     name: Notify Reviewers
     uses: ScribeMD/slack-templates/.github/workflows/notify-reviewers.yaml@main
+    permissions:
+      contents: read
     secrets:
       SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
       SLACK_REVIEW_CHANNEL_ID: ${{ secrets.SLACK_REVIEW_CHANNEL_ID }}

--- a/workflow-templates/test.yaml
+++ b/workflow-templates/test.yaml
@@ -10,6 +10,9 @@ jobs:
   test:
     name: Run Pre-commit Hooks
     uses: ScribeMD/pre-commit-action/.github/workflows/test.yaml@main
+    permissions:
+      contents: write
+      pull-requests: read
     secrets:
       SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
       SLACK_ACTIONS_CHANNEL_ID: ${{ secrets.SLACK_ACTIONS_CHANNEL_ID }}


### PR DESCRIPTION
Grant callable workflows the permissions they require in workflow templates. The Test workflow requires the `contents:write` and `pull-requests:read` scopes, and the Notify Assignee and Notify Reviewers workflows require the `contents:read` scope. In the Test workflow, pre-commit-action uses the `contents:write` scope to bump the project version via Commitizen, and slack-templates uses the `contents:read` and `pull-requests:read` scopes to determine the pull request associated with a push event to main since the push event itself doesn't contain this information. In the notify workflows, actions/checkout uses the `contents:read` scope to check out the calling repository. Granting these specific permissions also has the effect of reducing the scope of all unspecified permissions from read to none. Most data of public repositories can be read without additional permissions, but the `contents:read` and `pull-requests:read` scopes are needed in the callable workflows when the calling repository is private. Callable workflows can only be called when granted the permissions they require, so the same scopes are needed whether the calling repository is public or private.