### PR TITLE
docs(CONTRIBUTING): Prefer `$ASDF_DIR` to `~/.asdf`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,7 @@
 
   ```bash
   source ~/.asdf/asdf.sh
-  source ~/.asdf/completions/asdf.bash
+  source "$ASDF_DIR/completions/asdf.bash"
   ```
 
 - Close and relaunch Ubuntu to source your `~/.bashrc`.


### PR DESCRIPTION
Use the environment variable once it has been sourced to minimize hard-coding of paths.