### PR TITLE
docs(CONTRIBUTING): Pass `--sync` to `poetry install`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,7 +28,7 @@
 - Add the asdf plugin for all tools in [`.tool-versions`](.tool-versions) (e.g.,
   run `asdf plugin add nodejs` to install the Node.js plugin for asdf).
 - Run `asdf install` to install all asdf-managed tools at the pinned versions.
-- Run `poetry install` to install all Python dependencies.
+- Run `poetry install --sync` to install all Python dependencies.
 - Run `poetry shell` to activate the Poetry virtual environment.
 - Install all pre-commit hooks by running `pre-commit install --install-hooks`.
 


### PR DESCRIPTION
The recently released Poetry 1.2.0 introduced support for the `--sync` argument, which removes any dependencies not found in `poetry.lock` from the virtual environment.