### PR TITLE
docs(CONTRIBUTING): Tell Poetry to use asdf Python

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,6 +28,8 @@
 - Add the asdf plugin for all tools in [`.tool-versions`](.tool-versions) (e.g.,
   run `asdf plugin add nodejs` to install the Node.js plugin for asdf).
 - Run `asdf install` to install all asdf-managed tools at the pinned versions.
+- Run `poetry env use "$(asdf which python)"` to instruct Poetry to use the
+  asdf-managed Python.
 - Run `poetry install --sync` to install all Python dependencies.
 - Run `poetry shell` to activate the Poetry virtual environment.
 - Install all pre-commit hooks by running `pre-commit install --install-hooks`.


### PR DESCRIPTION
Upon upgrading from Poetry 1.1.15 to Poetry 1.2.0, we began using the newly introduced experimental `virtualenvs.prefer-active-python` setting via asdf-poetry. Recommend that contributors explicitly configure Poetry to use the asdf-managed version of Python in case it is not the active Python version in their shell.