### PR TITLE
fix(Renovate): Remove post-update tasks

### DIFF
--- a/default.json
+++ b/default.json
@@ -8,7 +8,6 @@
     "npm:unpublishSafe"
   ],
   "addLabels": ["dependencies"],
-  "allowedPostUpgradeCommands": ["yarn run build"],
   "commitBodyTable": true,
   "commitMessageAction": "Bump",
   "commitMessageTopic": "{{depName}} from {{#if isPinDigest}}{{{currentDigestShort}}}{{else}}{{#if isSingleVersion}}v{{currentVersion}}{{else}}{{#if newValue}}{{{currentValue}}}{{else}}{{{currentDigestShort}}}{{/if}}{{/if}}{{/if}}",
@@ -39,15 +38,6 @@
     {
       "matchDepTypes": ["devDependencies"],
       "semanticCommitScope": "deps-dev"
-    },
-    {
-      "matchManagers": ["yarn"],
-      "matchDepTypes": ["dependencies"],
-      "postUpgradeTasks": {
-        "commands": ["yarn run build"],
-        "fileFilters": ["*"],
-        "executionMode": "branch"
-      }
     },
     {
       "matchPaths": ["action.yaml"],


### PR DESCRIPTION
They are only supported when self-hosting Renovate, whereas we are running Renovate via the Mend-hosted Forking Renovate GitHub app. We will have to continue manually running `yarn run build` when bumping production Yarn dependencies in the docker-cache repository.

See renovatebot/renovate#18614.