### PR TITLE
fix(Renovate): Remove schedule

### DIFF
--- a/default.json
+++ b/default.json
@@ -168,7 +168,5 @@
       "depTypeTemplate": "dependencies"
     }
   ],
-  "schedule": ["after 8am and before 12pm"],
-  "semanticCommitScope": "deps",
-  "timezone": "America/New_York"
+  "semanticCommitScope": "deps"
 }


### PR DESCRIPTION
We require manual approval via the Dependency Dashboard before Renovate can open branches, and that feature is not compatible with scheduling, because Renovate creates the branches immediately upon their approval.

See renovatebot/renovate#18616.