### PR TITLE
fix(Renovate): Remove `platformCommit`

### DIFF
--- a/default.json
+++ b/default.json
@@ -37,7 +37,6 @@
       "semanticCommitType": "fix"
     }
   ],
-  "platformCommit": true,
   "postUpdateOptions": ["yarnDedupeHighest"],
   "prConcurrentLimit": 1,
   "prHourlyLimit": 0,


### PR DESCRIPTION
This feature is not supported by Forking Renovate, because it causes Renovate to attempt to create commits on the forked repository where it lacks write permissions rather than on the fork where it has them.