### PR TITLE
feat(Renovate): Add `regexManager` for asdf itself

### DIFF
--- a/default.json
+++ b/default.json
@@ -78,6 +78,14 @@
       "depTypeTemplate": "devDependencies"
     },
     {
+      "fileMatch": ["^action\\.yaml$"],
+      "matchStrings": [
+        "(?<depName>asdf)(-|_branch:\\s*)(?<currentValue>v\\d+\\.\\d+\\.\\d+)"
+      ],
+      "datasourceTemplate": "github-tags",
+      "depTypeTemplate": "engines"
+    },
+    {
       "fileMatch": [
         "^\\.pre-commit-config\\.yaml$",
         "^\\.tool-versions$",


### PR DESCRIPTION
Automatically bump the version of asdf used in CI. Developers must still manage the version of asdf used locally.