### PR TITLE
fix(Renovate): Narrow called workflow regex

### DIFF
--- a/default.json
+++ b/default.json
@@ -72,7 +72,7 @@
     {
       "fileMatch": ["^\\.github\\/workflows\\/[^/]+\\.yaml$"],
       "matchStrings": [
-        "uses:\\s*['\"]?(?<depName>[^/]+\\/[^/]+).*@(?<currentValue>\\d+\\.\\d+\\.\\d+)"
+        "uses:\\s*['\"]?(?<depName>[^/]+\\/[^/]+)\\/\\.github\\/workflows\\/[^/]+\\.yaml@(?<currentValue>\\d+\\.\\d+\\.\\d+)"
       ],
       "datasourceTemplate": "github-tags",
       "depTypeTemplate": "devDependencies"


### PR DESCRIPTION
Prevent the regex for the called workflow regex manager from matching conventional GitHub Actions to address Renovate warnings.