### PR TITLE
fix(Renovate): Configure asdf source repository

### DIFF
--- a/default.json
+++ b/default.json
@@ -83,6 +83,7 @@
         "(?<depName>asdf)(-|_branch:\\s*)(?<currentValue>v\\d+\\.\\d+\\.\\d+)"
       ],
       "datasourceTemplate": "github-tags",
+      "packageNameTemplate": "asdf-vm/asdf",
       "depTypeTemplate": "engines"
     },
     {


### PR DESCRIPTION
Address a Renovate warning that prevents asdf itself from being automatically updated. Configure Renovate to scan the GitHub tags of [asdf-vm/asdf](https://github.com/asdf-vm/asdf) to check for new releases of asdf.