### PR TITLE
fix(Renovate): Remove called workflow re manager

### DIFF
--- a/default.json
+++ b/default.json
@@ -70,14 +70,6 @@
       "extractVersionTemplate": "^win(?<version>\\d+)\\/"
     },
     {
-      "fileMatch": ["^\\.github\\/workflows\\/[^/]+\\.yaml$"],
-      "matchStrings": [
-        "uses:\\s*['\"]?(?<depName>[^/]+\\/[^/]+)\\/\\.github\\/workflows\\/[^/]+\\.yaml@(?<currentValue>\\d+\\.\\d+\\.\\d+)"
-      ],
-      "datasourceTemplate": "github-tags",
-      "depTypeTemplate": "devDependencies"
-    },
-    {
       "fileMatch": ["^action\\.yaml$"],
       "matchStrings": [
         "(?<depName>asdf)(-|_branch:\\s*)(?<currentValue>v\\d+\\.\\d+\\.\\d+)"


### PR DESCRIPTION
Renovate's github-actions manager already upgrades called workflows, so there is no need for our custom called workflow regex manager.