### PR TITLE
feat(Renovate): Add re manager for Renovate config

### DIFF
--- a/default.json
+++ b/default.json
@@ -58,6 +58,14 @@
   "rangeStrategy": "bump",
   "regexManagers": [
     {
+      "fileMatch": ["^\\.github\\/renovate\\.json$"],
+      "matchStrings": [
+        "github>(?<depName>ScribeMD/.github)#(?<currentValue>(\\d+\\.){2}\\d+)"
+      ],
+      "datasourceTemplate": "github-tags",
+      "depTypeTemplate": "engines"
+    },
+    {
       "fileMatch": ["^\\.github\\/workflows\\/[^/]+\\.yaml$"],
       "matchStrings": [
         "runs-on:\\s*['\"]?(?<depName>ubuntu)-(?<currentValue>\\d+)\\.04"


### PR DESCRIPTION
Add a regex manager so Renovate automatically bumps the version of the Renovate config used in downstream repositories.