### PR TITLE
fix(Renovate): Escape `^` in Python regex manager

### DIFF
--- a/default.json
+++ b/default.json
@@ -101,7 +101,7 @@
         "^pyproject\\.toml$"
       ],
       "matchStrings": [
-        "(?<depName>python)\\s*(=\\s*\"^)?(?<currentValue>(\\d+\\.){2}\\d+)"
+        "(?<depName>python)\\s*(=\\s*\"\\^)?(?<currentValue>(\\d+\\.){2}\\d+)"
       ],
       "datasourceTemplate": "github-tags",
       "packageNameTemplate": "python/cpython",


### PR DESCRIPTION
The regex intended to match a literal caret character in `pyproject.toml`.