### PR TITLE
feat(GitHub-Actions): Pin starter workflows

### DIFF
--- a/workflow-templates/notify-assignee.yaml
+++ b/workflow-templates/notify-assignee.yaml
@@ -6,7 +6,7 @@ on:
 jobs:
   notify-assignee:
     name: Notify Assignee
-    uses: ScribeMD/slack-templates/.github/workflows/notify-assignee.yaml@main
+    uses: ScribeMD/slack-templates/.github/workflows/notify-assignee.yaml@0.6.12
     permissions:
       contents: read
     secrets:

--- a/workflow-templates/notify-reviewers.yaml
+++ b/workflow-templates/notify-reviewers.yaml
@@ -6,7 +6,7 @@ on:
 jobs:
   notify-reviewers:
     name: Notify Reviewers
-    uses: ScribeMD/slack-templates/.github/workflows/notify-reviewers.yaml@main
+    uses: ScribeMD/slack-templates/.github/workflows/notify-reviewers.yaml@0.6.12
     permissions:
       contents: read
     secrets:

--- a/workflow-templates/test.yaml
+++ b/workflow-templates/test.yaml
@@ -9,7 +9,7 @@ on:
 jobs:
   test:
     name: Run Pre-commit Hooks
-    uses: ScribeMD/pre-commit-action/.github/workflows/test.yaml@main
+    uses: ScribeMD/pre-commit-action/.github/workflows/test.yaml@0.9.29
     permissions:
       contents: write
       pull-requests: read


### PR DESCRIPTION
Renovate will automatically bump them, so pin the called workflows to eliminate a manual step in the use of the starter workflows. Pin [pre-commit-action](https://github.com/ScribeMD/pre-commit-action) to 0.9.29 for the Run Pre-commit Hooks workflow and [slack-templates](https://github.com/ScribeMD/slack-templates) to 0.6.12 for the Notify Assignee and Notify Reviewers workflows.