### PR TITLE
fix(Renovate): Use fix for mega-linter-runner

### DIFF
--- a/default.json
+++ b/default.json
@@ -41,7 +41,7 @@
       "groupName": "MegaLinter"
     },
     {
-      "matchPaths": ["action.yaml"],
+      "matchPaths": ["action.yaml", "mega-linter-runner"],
       "semanticCommitType": "fix"
     }
   ],


### PR DESCRIPTION
The mega-linter-runner version is part of the API of pre-commit-hooks, so bump the former when we bump the latter.