### PR TITLE
fix(Renovate): Use fix for `.pre-commit-hooks.yaml`

### DIFF
--- a/default.json
+++ b/default.json
@@ -41,7 +41,7 @@
       "groupName": "MegaLinter"
     },
     {
-      "matchPaths": ["action.yaml", "mega-linter-runner"],
+      "matchPaths": [".pre-commit-hooks.yaml", "action.yaml"],
       "semanticCommitType": "fix"
     }
   ],


### PR DESCRIPTION
`.pre-commit-hooks.yaml` contains pre-commit hook definitions. mega-linter-runner is a package in this file, not a filename, so it was incorrect to specify it as a path to match.