### PR TITLE
fix(Renovate): Don't wait 3 days for npm updates

### DIFF
--- a/default.json
+++ b/default.json
@@ -4,8 +4,7 @@
   "extends": [
     "config:base",
     ":assignAndReview(Kurt-von-Laven)",
-    "helpers:disableTypesNodeMajor",
-    "npm:unpublishSafe"
+    "helpers:disableTypesNodeMajor"
   ],
   "addLabels": ["dependencies"],
   "commitBodyTable": true,


### PR DESCRIPTION
For the most part, Renovate's stability feature has no effect since we use a Dependency Dashboard instead of a schedule. While Renovate ignores the setting for most dependencies when a PR is opened via the Dependency Dashboard, it does honor it for certain grouped dependencies, such as Node.js itself and mega-linter-runner. Hence, it prevents us from automatically applying security patches to Node.js quickly. For the most part the setting does not have its intended effect of protecting us from packages that are unpublished from npm within 72 hours of their publication.