### PR TITLE
fix(Renovate): Broaden MegaLinter package pattern

### DIFF
--- a/default.json
+++ b/default.json
@@ -36,7 +36,7 @@
       "groupName": "commitizen"
     },
     {
-      "matchPackagePatterns": ["mega-?linter"],
+      "matchPackagePatterns": ["[Mm]ega-?[Ll]inter"],
       "groupName": "MegaLinter"
     },
     {


### PR DESCRIPTION
Match packages with "MegaLinter" in their name regardless of casing. `matchPackagePatterns` matches dependency names rather than package names, so it failed to match the MegaLinter Docker image regex manager, preventing MegaLinter upgrades from being grouped with mega-linter-runner upgrades.