### PR TITLE
fix(Renovate): Prefer `matchFiles` to `matchPaths`

### DIFF
--- a/default.json
+++ b/default.json
@@ -40,7 +40,7 @@
       "groupName": "MegaLinter"
     },
     {
-      "matchPaths": [".pre-commit-hooks.yaml", "action.yaml"],
+      "matchFiles": [".pre-commit-hooks.yaml", "action.yaml"],
       "semanticCommitType": "fix"
     }
   ],


### PR DESCRIPTION
The latter correctly matches action.yaml but incorrectly fails to match `.pre-commit-hooks.yaml`. We don't require the flexibility of matching minimatch patterns, so match literal filenames instead.