### PR TITLE
fix(Renovate): Don't use schedule for lock files

### DIFF
--- a/default.json
+++ b/default.json
@@ -24,7 +24,8 @@
     "addLabels": ["javascript"]
   },
   "lockFileMaintenance": {
-    "enabled": true
+    "enabled": true,
+    "schedule": ["at any time"]
   },
   "packageRules": [
     {


### PR DESCRIPTION
By default, Renovate schedules lock file maintenance between 12 and 5 a.m. UTC on Mondays. If the pull request is merged during the window, Renovate usually immediately opens a new duplicate or vacuous (whitespace-only) branch. Change the schedule to "at any time," which really means no schedule at all since the Dependency Dashboard is enabled.

See renovatebot/renovate#18794 for more details.