### PR TITLE
fix(Renovate): Schedule lock file maintenance for 1970

### DIFF
--- a/default.json
+++ b/default.json
@@ -25,7 +25,7 @@
   },
   "lockFileMaintenance": {
     "enabled": true,
-    "schedule": ["at any time"]
+    "schedule": ["in 1970"]
   },
   "packageRules": [
     {


### PR DESCRIPTION
Renovate handles lock file maintenance specially in that its schedule is not overridden by the Dependency Dashboard. Since lock file maintenance was scheduled "at any time," whenever lock file maintenance pull requests were merged, Renovate immediately opened a new duplicate or vacuous (whitespace-only) branch. Schedule lock file maintenance for the distant past as a workaround to effectively disable its schedule, allowing it to be managed via the Dependency Dashboard.