### PR TITLE
fix(Renovate): Specify date to address warning

### DIFF
--- a/default.json
+++ b/default.json
@@ -25,7 +25,7 @@
   },
   "lockFileMaintenance": {
     "enabled": true,
-    "schedule": ["in 1970"]
+    "schedule": ["on 29th of February in 1970"]
   },
   "packageRules": [
     {


### PR DESCRIPTION
Renovate complains when the schedule "has no months, days of week or time of day."