### PR TITLE
fix(Renovate): Correct lock file maintenance schedule

### DIFF
--- a/default.json
+++ b/default.json
@@ -25,7 +25,7 @@
   },
   "lockFileMaintenance": {
     "enabled": true,
-    "schedule": ["on 29th of February in 1970"]
+    "schedule": ["on the 29th day of February in 1970"]
   },
   "packageRules": [
     {


### PR DESCRIPTION
The [Later.js grammar](https://breejs.github.io/later/parsers.html#text) expects a day of the week to follow "on," so switch to "on the," which can be followed by a day of the month.