### PR TITLE
fix(Renovate): Remove asdf Python regex manager

### DIFF
--- a/default.json
+++ b/default.json
@@ -95,13 +95,9 @@
       "depTypeTemplate": "engines"
     },
     {
-      "fileMatch": [
-        "^\\.pre-commit-config\\.yaml$",
-        "^\\.tool-versions$",
-        "^pyproject\\.toml$"
-      ],
+      "fileMatch": ["^\\.pre-commit-config\\.yaml$", "^pyproject\\.toml$"],
       "matchStrings": [
-        "(?<depName>python)\\s*(=\\s*\"\\^)?(?<currentValue>(\\d+\\.){2}\\d+)"
+        "(?<depName>python)(\\s*=\\s*\"\\^)?(?<currentValue>(\\d+\\.){2}\\d+)"
       ],
       "datasourceTemplate": "github-tags",
       "packageNameTemplate": "python/cpython",


### PR DESCRIPTION
Renovate recently added first-class support for bumping the Python version managed by asdf.