### PR TITLE
fix(Renovate): Correct mega-linter-runner dep type

### DIFF
--- a/default.json
+++ b/default.json
@@ -33,7 +33,7 @@
       "semanticCommitScope": "deps-dev"
     },
     {
-      "matchFiles": [".pre-commit-hooks.yaml", "action.yaml"],
+      "matchFiles": ["action.yaml"],
       "semanticCommitType": "fix"
     },
     {
@@ -155,7 +155,7 @@
         "(?<depName>mega-linter-runner)@v(?<currentValue>(\\d+\\.){2}\\d+)"
       ],
       "datasourceTemplate": "npm",
-      "depTypeTemplate": "devDependencies"
+      "depTypeTemplate": "dependencies"
     },
     {
       "fileMatch": ["^\\.mega-linter\\.yaml$"],


### PR DESCRIPTION
Change mega-linter-runner from a development to a production dependency since its version is part of the API of the pre-commit-hooks repository. Remove no longer needed package rule instructing Renovate to use the fix commit type with any pull request that modifies `.pre-commit-hooks.yaml`. Renovate did not honor this package rule anyways, and correcting the dependency type achieves the intended effect of instructing Renovate to use the fix commit type when bumping mega-linter-runner.