### PR TITLE
fix(Renovate): Stop grouping MegaLinter bumps

### DIFF
--- a/default.json
+++ b/default.json
@@ -39,10 +39,6 @@
     {
       "matchPackageNames": ["commitizen", "commitizen-tools/commitizen"],
       "groupName": "commitizen"
-    },
-    {
-      "matchPackagePatterns": ["[Mm]ega-?[Ll]inter"],
-      "groupName": "MegaLinter"
     }
   ],
   "postUpdateOptions": ["yarnDedupeHighest"],


### PR DESCRIPTION
Only the pre-commit-hooks repository contains multiple MegaLinter dependencies, and it now groups MegaLinter bumps in its own Renovate config. Renovate does not currently offer a flexible mechanism by which a shared config can use `chore` for bumps of a group in some cases but `fix` in others. Every repository has a development dependency on a MegaLinter Docker image, so excluding the pre-commit-hooks repository, `chore` will be correctly used when it's bumped.