### PR TITLE
fix(Renovate): Require approval to create PRs

### DIFF
--- a/default.json
+++ b/default.json
@@ -43,6 +43,7 @@
   ],
   "postUpdateOptions": ["yarnDedupeHighest"],
   "prConcurrentLimit": 1,
+  "prCreation": "approval",
   "prHourlyLimit": 0,
   "pre-commit": {
     "addLabels": ["pre-commit"],


### PR DESCRIPTION
Dependency Dashboard approval is already enabled, but lock file maintenance follows a schedule regardless. Lock file maintenance was disabled by configuring it with a vacuous schedule, but explicitly requiring approval to create PRs defends against similar issues in the future.