### PR TITLE
fix(Renovate): Use pin `rangeStrategy`

### DIFF
--- a/default.json
+++ b/default.json
@@ -52,7 +52,7 @@
   "python": {
     "addLabels": ["python"]
   },
-  "rangeStrategy": "bump",
+  "rangeStrategy": "pin",
   "regexManagers": [
     {
       "fileMatch": ["^\\.github\\/renovate\\.json$"],


### PR DESCRIPTION
We recently adopted [Renovate's recommendation of pinning all of our direct dependencies to exact versions rather than using ranges](https://docs.renovatebot.com/dependency-pinning/), so configure Renovate to enforce pinning.