### PR TITLE
fix(Renovate): Replace `^` with `==` in Python regex

### DIFF
--- a/default.json
+++ b/default.json
@@ -94,7 +94,7 @@
     {
       "fileMatch": ["^\\.pre-commit-config\\.yaml$", "^pyproject\\.toml$"],
       "matchStrings": [
-        "(?<depName>python)(\\s*=\\s*\"\\^)?(?<currentValue>(\\d+\\.){2}\\d+)"
+        "(?<depName>python)(\\s*=\\s*\"==)?(?<currentValue>(\\d+\\.){2}\\d+)"
       ],
       "datasourceTemplate": "github-tags",
       "packageNameTemplate": "python/cpython",


### PR DESCRIPTION
The Python version constraint was changed from `^` to `==` in `pyproject.toml`, so update the corresponding regex manager accordingly.