### PR TITLE
fix(Renovate): Don't require PR creation approval

### DIFF
--- a/default.json
+++ b/default.json
@@ -43,7 +43,6 @@
   ],
   "postUpdateOptions": ["yarnDedupeHighest"],
   "prConcurrentLimit": 1,
-  "prCreation": "approval",
   "prHourlyLimit": 0,
   "pre-commit": {
     "addLabels": ["pre-commit"],


### PR DESCRIPTION
Forking Renovate is unable to open lock file maintenance pull requests when PR creation requires approval.