### PR TITLE
feat(Renovate): Add manager for MegaLinter config

### DIFF
--- a/default.json
+++ b/default.json
@@ -159,6 +159,14 @@
     },
     {
       "fileMatch": ["^\\.mega-linter\\.yaml$"],
+      "matchStrings": [
+        "https://raw\\.githubusercontent\\.com/(?<depName>ScribeMD/\\.github)/(?<currentValue>(\\d+\\.){2}\\d+)"
+      ],
+      "datasourceTemplate": "github-tags",
+      "depTypeTemplate": "devDependencies"
+    },
+    {
+      "fileMatch": ["^\\.mega-linter\\.yaml$"],
       "matchStrings": ["(?<depName>\\S+)@(?<currentValue>(\\d+\\.){2}\\d+)"],
       "datasourceTemplate": "npm",
       "depTypeTemplate": "devDependencies"


### PR DESCRIPTION
Add a regex manager so Renovate automatically bumps the version of the base MegaLinter configs extended in downstream repositories.