### PR TITLE
fix(Renovate): Escape `.` in Renovate regex manager

### DIFF
--- a/default.json
+++ b/default.json
@@ -60,7 +60,7 @@
     {
       "fileMatch": ["^\\.github\\/renovate\\.json$"],
       "matchStrings": [
-        "github>(?<depName>ScribeMD/.github)#(?<currentValue>(\\d+\\.){2}\\d+)"
+        "github>(?<depName>ScribeMD/\\.github)#(?<currentValue>(\\d+\\.){2}\\d+)"
       ],
       "datasourceTemplate": "github-tags",
       "depTypeTemplate": "engines"


### PR DESCRIPTION
The regex intended to match a literal period rather than any character.