### PR TITLE
fix(Renovate): Correct asdf bump commit messages

### DIFF
--- a/default.json
+++ b/default.json
@@ -88,11 +88,12 @@
     {
       "fileMatch": ["^action\\.yaml$"],
       "matchStrings": [
-        "(?<depName>asdf)(-|_branch:\\s*)(?<currentValue>v(\\d+\\.){2}\\d+)"
+        "(?<depName>asdf)(-|_branch:\\s*)v(?<currentValue>(\\d+\\.){2}\\d+)"
       ],
       "packageNameTemplate": "asdf-vm/asdf",
       "datasourceTemplate": "github-tags",
-      "depTypeTemplate": "engines"
+      "depTypeTemplate": "engines",
+      "extractVersionTemplate": "^v(?<version>.*)$"
     },
     {
       "fileMatch": ["^\\.pre-commit-config\\.yaml$", "^pyproject\\.toml$"],


### PR DESCRIPTION
Replace "vv" with "v" in asdf commit messages and pull request titles. `commitMessageTopic` prefixes `currentVersion` with a "v," so don't include the "v" in the version matched by the asdf regex manager. Introduce an `extractVersionTemplate` to trim the leading "v" off the asdf GitHub tag.