### PR TITLE
fix(Renovate): Group MegaLinter Python linters

### DIFF
--- a/default.json
+++ b/default.json
@@ -45,6 +45,18 @@
       "groupName": "commitizen"
     },
     {
+      "matchPackageNames": [
+        "bandit",
+        "black",
+        "flake8",
+        "isort",
+        "mypy",
+        "oxsecurity/megalinter-python",
+        "pylint"
+      ],
+      "groupName": "MegaLinter"
+    },
+    {
       "matchPackageNames": ["pre-commit", "pre-commit/pre-commit"],
       "groupName": "pre-commit"
     },


### PR DESCRIPTION
We run Bandit, Black, Flake8, isort, mypy, and Pylint via both the Python flavor of MegaLinter and the Python VSCode extension. Configure Renovate to group updates to these dependencies along with updates to the Python MegaLinter flavor. This makes it easier to keep the linters in sync with their versions in MegaLinter so that linting in MegaLinter and VSCode yields the same results.