### PR TITLE
fix(Renovate): Add `depName` `"MegaLinter"` to group

### DIFF
--- a/default.json
+++ b/default.json
@@ -50,6 +50,7 @@
         "black",
         "flake8",
         "isort",
+        "MegaLinter",
         "mypy",
         "oxsecurity/megalinter-python",
         "pylint"


### PR DESCRIPTION
`matchPackageNames` currently matches `depName`s, so add the `depName` of the MegaLinter Docker image, namely `"MegaLinter"`, to a list of package names to group. Renovate plans to change the behavior of `matchPackageNames` to match `packageNames` in the future, so leave the `packageName` of the MegaLinter Python flavor, namely `"oxsecurity/megalinter-python"`, in the list.