### PR TITLE
fix(Renovate): Don't separate major version bumps

### DIFF
--- a/default.json
+++ b/default.json
@@ -208,5 +208,6 @@
       "depTypeTemplate": "dependencies"
     }
   ],
-  "semanticCommitScope": "deps"
+  "semanticCommitScope": "deps",
+  "separateMajorMinor": false
 }


### PR DESCRIPTION
Doing so prevents major version bumps from being grouped.