### PR TITLE
chore(VSCode): Set Python to 4-space indentation

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,6 +8,10 @@ charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
 
+# Match the default pycodestyle style.
+[*.py]
+indent_size = 4
+
 [*.diff]
 # Preserve trailing whitespace so as not to break Git patch editing.
 trim_trailing_whitespace = false

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,6 +2,9 @@
   "[diff]": {
     "files.trimTrailingWhitespace": false
   },
+  "[python]": {
+    "editor.tabSize": 4
+  },
   "editor.tabSize": 2,
   "editorconfig.generateAuto": false,
   "files.eol": "\n",


### PR DESCRIPTION
Configure VSCode and EditorConfig to follow the PEP 8 style guideline of 4-space indentation in Python. We don't track any Python files in this repository, but Poetry does install Python dependencies to `.venv`.