### PR TITLE
fix(Renovate): Replace Flake8, isort, and pydocstyle with Ruff

### DIFF
--- a/default.json
+++ b/default.json
@@ -48,22 +48,17 @@
       "matchPackageNames": [
         "bandit",
         "black",
-        "flake8",
-        "isort",
         "MegaLinter",
         "mypy",
         "oxsecurity/megalinter-python",
-        "pylint"
+        "pylint",
+        "ruff"
       ],
       "groupName": "MegaLinter"
     },
     {
       "matchPackageNames": ["pre-commit", "pre-commit/pre-commit"],
       "groupName": "pre-commit"
-    },
-    {
-      "matchPackageNames": ["pydocstyle", "PyCQA/pydocstyle"],
-      "groupName": "pydocstyle"
     }
   ],
   "postUpdateOptions": ["yarnDedupeHighest"],


### PR DESCRIPTION
Ruff was recently added to MegaLinter in v6.22.0. Ruff reimplements many other Python linters, including Flake8, isort, and pydocstyle in Rust to dramatically improve performance. Replace the reimplemented linters in the Renovate config so that bumps of the MegaLinter Python flavor continue to be grouped correctly.