### PR TITLE
fix(Renovate): Remove asdf Poetry regex manager

### DIFF
--- a/default.json
+++ b/default.json
@@ -123,15 +123,6 @@
     },
     {
       "fileMatch": ["^\\.tool-versions$"],
-      "matchStrings": [
-        "(?<depName>poetry)\\s+(?<currentValue>(\\d+\\.){2}\\d+)"
-      ],
-      "packageNameTemplate": "python-poetry/poetry",
-      "datasourceTemplate": "github-tags",
-      "depTypeTemplate": "engines"
-    },
-    {
-      "fileMatch": ["^\\.tool-versions$"],
       "matchStrings": ["(?<depName>yarn)\\s+(?<currentValue>(\\d+\\.){2}\\d+)"],
       "packageNameTemplate": "yarnpkg/yarn",
       "datasourceTemplate": "github-tags",


### PR DESCRIPTION
Renovate recently added first-class support for bumping the Poetry version managed by asdf.