### PR TITLE
fix(MegaLinter): Disable ts-standard

### DIFF
--- a/.github/base.mega-linter.yaml
+++ b/.github/base.mega-linter.yaml
@@ -8,6 +8,7 @@ DISABLE_LINTERS:
   - GRAPHQL_GRAPHQL_SCHEMA_LINTER
   - PYTHON_FLAKE8 # Superseded by Ruff
   - PYTHON_ISORT # Superseded by Ruff
+  - TYPESCRIPT_STANDARD # We use Prettier instead.
 FAIL_IF_MISSING_LINTER_IN_FLAVOR: true
 FILTER_REGEX_EXCLUDE: \.pnp\.(c|loader\.m)js|\.yarn|dist
 FORMATTERS_DISABLE_ERRORS: false


### PR DESCRIPTION
ts-standard was recently added to MegaLinter in v7.2.0. Disable it since we use Prettier, which is incompatible with StandardJS.