### PR TITLE
feat(Renovate): Bump Yarn in MegaLinter config

### DIFF
--- a/default.json
+++ b/default.json
@@ -175,6 +175,14 @@
     },
     {
       "fileMatch": ["^\\.mega-linter\\.yaml$"],
+      "matchStrings": ["(?<depName>yarn)-(?<currentValue>(\\d+\\.){2}\\d+)"],
+      "packageNameTemplate": "yarnpkg/berry",
+      "datasourceTemplate": "github-tags",
+      "depTypeTemplate": "engines",
+      "extractVersionTemplate": "^@yarnpkg/cli/(?<version>.*)$"
+    },
+    {
+      "fileMatch": ["^\\.mega-linter\\.yaml$"],
       "matchStrings": ["(?<depName>\\S+)@(?<currentValue>(\\d+\\.){2}\\d+)"],
       "datasourceTemplate": "npm",
       "depTypeTemplate": "devDependencies"


### PR DESCRIPTION
MegaLinter recently added support for arrays to `*_CLI_EXECUTABLE` in v7.0.0. This allowed us to run the version of ESLint installed in our project via Yarn in lieu of the version of ESLint in the MegaLinter Docker image via npm. This avoided many complications that arose from ESLint being unable to access Yarn dependencies and allowed us to stop running ESLint in project mode as a workaround. However, it required us to specify the full path to the Yarn executable in the MegaLinter config, so ensure that gets bumped during Yarn upgrades.