### PR TITLE
feat(Renovate): Generalize raw file regex manager

### DIFF
--- a/default.json
+++ b/default.json
@@ -166,12 +166,13 @@
       "depTypeTemplate": "dependencies"
     },
     {
-      "fileMatch": ["^\\.mega-linter\\.yaml$"],
+      "fileMatch": ["^\\.mega-linter\\.yaml$", "^\\.yarnrc\\.yml$"],
       "matchStrings": [
-        "https://raw\\.githubusercontent\\.com/(?<depName>ScribeMD/\\.github)/(?<currentValue>(\\d+\\.){2}\\d+)"
+        "https://raw\\.githubusercontent\\.com/(?<depName>[^/]+/[^/]+)/v?(?<currentValue>(\\d+\\.){2}\\d+)"
       ],
       "datasourceTemplate": "github-tags",
-      "depTypeTemplate": "devDependencies"
+      "depTypeTemplate": "devDependencies",
+      "extractVersionTemplate": "^v?(?<version>.*)$"
     },
     {
       "fileMatch": ["^\\.mega-linter\\.yaml$"],


### PR DESCRIPTION
Match any owner and repository in raw GitHub file URLs rather than hardcoding `ScribeMD/.github`. Add `.yarnrc.yml` to the list of files scanned by this regex manager since the Yarn licenses plugin is a raw GitHub file.