### PR TITLE
fix(Renovate): Get Yarn from npm instead of GitHub

### DIFF
--- a/default.json
+++ b/default.json
@@ -177,10 +177,9 @@
     {
       "fileMatch": ["^\\.mega-linter\\.yaml$"],
       "matchStrings": ["(?<depName>yarn)-(?<currentValue>(\\d+\\.){2}\\d+)"],
-      "packageNameTemplate": "yarnpkg/berry",
-      "datasourceTemplate": "github-tags",
-      "depTypeTemplate": "engines",
-      "extractVersionTemplate": "^@yarnpkg/cli/(?<version>.*)$"
+      "packageNameTemplate": "@yarnpkg/cli",
+      "datasourceTemplate": "npm",
+      "depTypeTemplate": "engines"
     },
     {
       "fileMatch": ["^\\.mega-linter\\.yaml$"],


### PR DESCRIPTION
In the regex manager that bumps Yarn v2+ in the MegaLinter config, use the same datasource that Renovate does for Yarn v2+ to eliminate a race condition where the GitHub tag has been published but the corresponding version of the npm package hasn't yet been released.