### PR TITLE
fix(Renovate): Assign Code Review to Dependency Management

### DIFF
--- a/default.json
+++ b/default.json
@@ -3,7 +3,7 @@
   "description": "Renovate config for ScribeMD in the style of Dependabot",
   "extends": [
     "config:base",
-    ":assignAndReview(Kurt-von-Laven)",
+    ":assignAndReview(ScribeMD/dependency-management)",
     "helpers:disableTypesNodeMajor"
   ],
   "addLabels": ["dependencies"],


### PR DESCRIPTION
Configure Renovate to request review from the Dependency Management team rather than me personally to make our shared Renovate config more general.