### PR TITLE
fix(Renovate): Correct team reviewer syntax

### DIFF
--- a/default.json
+++ b/default.json
@@ -4,7 +4,7 @@
   "extends": [
     "config:base",
     ":assignee(Kurt-von-Laven)",
-    ":reviewer(ScribeMD/dependency-management)",
+    ":reviewer(team:dependency-management)",
     "helpers:disableTypesNodeMajor"
   ],
   "addLabels": ["dependencies"],


### PR DESCRIPTION
According to [Renovate's official documentation](https://docs.renovatebot.com/configuration-options/#reviewers): "If you're assigning a team to review on GitHub, you must use the prefix team: and add the last part of the team name."