### PR TITLE
fix(Renovate): Port autopep8 off mirror

### DIFF
--- a/.dictionary.txt
+++ b/.dictionary.txt
@@ -1,1 +1,2 @@
+hhatto
 Laven

--- a/default.json
+++ b/default.json
@@ -38,7 +38,7 @@
       "semanticCommitType": "fix"
     },
     {
-      "matchPackageNames": ["autopep8", "pre-commit/mirrors-autopep8"],
+      "matchPackageNames": ["autopep8", "hhatto/autopep8"],
       "groupName": "autopep8"
     },
     {


### PR DESCRIPTION
The official autopep8 repository, `hhatto/autopep8`, recently added a pre-commit hook in v2.0.3, so it is no longer necessary to use a mirror.