### PR TITLE
feat(Renovate): Add regex manager for Yarn SDKs

### DIFF
--- a/default.json
+++ b/default.json
@@ -195,6 +195,14 @@
       "depTypeTemplate": "devDependencies"
     },
     {
+      "fileMatch": ["^\\.yarn/sdks/[^/]+/package\\.json$"],
+      "matchStrings": [
+        "\"name\":\\s*\"(?<depName>[^\"]+)\",\\s*\"version\":\\s*\"(?<currentValue>(\\d+\\.){2}\\d+)-sdk\""
+      ],
+      "datasourceTemplate": "npm",
+      "depTypeTemplate": "devDependencies"
+    },
+    {
       "fileMatch": ["^action\\.yaml$"],
       "matchStrings": [
         "(?<depName>commitizen)_version:\\s*(?<currentValue>(\\d+\\.){2}\\d+)"


### PR DESCRIPTION
Yarn currently offers SDKs for ESLint, Prettier, and TypeScript that should be updated when the corresponding npm packages are updated. Renovate can't run arbitrary commands, so maintainers must run `yarn run sdks` manually on such pull requests to complete the bump.