### PR TITLE
ci(dictionary): Remove "Gitleaks" and "hhatto"

### DIFF
--- a/.dictionary.txt
+++ b/.dictionary.txt
@@ -1,3 +1,1 @@
-Gitleaks
-hhatto
 Laven


### PR DESCRIPTION
"Gitleaks" was added to the software-terms and "hhatto" to the Python dictionary upstream, so remove them from our custom dictionary.