### PR TITLE
fix(Renovate): Group more deps with MegaLinter

### DIFF
--- a/default.json
+++ b/default.json
@@ -50,11 +50,14 @@
         "bandit",
         "black",
         "MegaLinter",
+        "mega-linter-runner",
         "mypy",
-        "oxsecurity/megalinter-python",
+        "prettier",
         "pylint",
-        "ruff"
+        "ruff",
+        "ScribeMD/pre-commit-hooks"
       ],
+      "matchPackagePrefixes": ["oxsecurity/megalinter"],
       "groupName": "MegaLinter"
     },
     {


### PR DESCRIPTION
We offer two pre-commit hooks that pin mega-linter-runner, `megalinter-incremental` and `megalinter-full`. Since mega-linter-runner releases typically parallel MegaLinter releases, group all MegaLinter flavors, mega-linter-runner, and our pre-commit-hooks with MegaLinter bumps.

MegaLinter runs Prettier, and we install Prettier locally, so group Prettier with MegaLinter to ensure consistent results between running Prettier via MegaLinter and running it directly.