### PR TITLE
fix(Renovate): Add `mergeConfidence:all-badges`

### DIFF
--- a/default.json
+++ b/default.json
@@ -5,7 +5,8 @@
     "config:base",
     ":assignee(Kurt-von-Laven)",
     ":reviewer(team:dependency-management)",
-    "helpers:disableTypesNodeMajor"
+    "helpers:disableTypesNodeMajor",
+    "mergeConfidence:all-badges"
   ],
   "addLabels": ["dependencies"],
   "commitBodyTable": true,


### PR DESCRIPTION
Renovate added merge confidence presets in v36.8.0. Merge confidence badges display the age of the new package version along with its adoption among Renovate users, the percentage of Renovate repositories on which the new version passes CI, and an overall confidence score for the update. Merge confidence badges have been enabled automatically for us, because we use Forking Renovate, but specify them explicitly for consistency if self-hosting Renovate.