### PR TITLE
fix(Renovate): Adopt `config:best-practices`

### DIFF
--- a/default.json
+++ b/default.json
@@ -2,7 +2,7 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "description": "Renovate config for ScribeMD in the style of Dependabot",
   "extends": [
-    "config:base",
+    "config:best-practices",
     ":assignee(Kurt-von-Laven)",
     ":reviewer(team:dependency-management)",
     "helpers:disableTypesNodeMajor",


### PR DESCRIPTION
The `config:base` preset was renamed to `config:recommended` in Renovate v36.0.0. `config:best-practices` was added in v36.104.0 to formalize Renovate's guidance. `config:best-practices` increases security by pinning digests for Docker images and GitHub Actions. It also pins dev dependencies, but we already pin all dependencies.