### PR TITLE
fix(Renovate): Add commit scope for each `depType`

### DIFF
--- a/default.json
+++ b/default.json
@@ -35,6 +35,14 @@
       "semanticCommitScope": "deps-dev"
     },
     {
+      "matchDepTypes": ["engines"],
+      "semanticCommitScope": "engines"
+    },
+    {
+      "matchDepTypes": ["packageManager"],
+      "semanticCommitScope": "pkg-manager"
+    },
+    {
       "matchFiles": ["action.yaml"],
       "semanticCommitType": "fix"
     },


### PR DESCRIPTION
Configure Renovate to place `engines` rather than `deps` in parentheses after the commit type when bumping dependencies of type `engines`. Use commit scope `pkg-manager` for dependencies of type `packageManager`. Previously, the `engines` and `packageManager` `depType`s were largely invisible to the developer unless they viewed the Renovate logs.