### PR TITLE
fix(Renovate): Correct some dependency types

### DIFF
--- a/default.json
+++ b/default.json
@@ -31,6 +31,10 @@
   },
   "packageRules": [
     {
+      "matchDepTypes": ["config"],
+      "semanticCommitScope": "config"
+    },
+    {
       "matchDepTypes": ["dev-dependencies", "devDependencies"],
       "semanticCommitScope": "deps-dev"
     },
@@ -93,7 +97,7 @@
         "github>(?<depName>ScribeMD/\\.github)#(?<currentValue>(\\d+\\.){2}\\d+)"
       ],
       "datasourceTemplate": "github-tags",
-      "depTypeTemplate": "engines"
+      "depTypeTemplate": "config"
     },
     {
       "customType": "regex",
@@ -125,7 +129,7 @@
       ],
       "packageNameTemplate": "asdf-vm/asdf",
       "datasourceTemplate": "github-tags",
-      "depTypeTemplate": "engines",
+      "depTypeTemplate": "packageManager",
       "extractVersionTemplate": "^v(?<version>.*)$"
     },
     {
@@ -145,7 +149,7 @@
       "matchStrings": ["(?<depName>yarn)\\s+(?<currentValue>(\\d+\\.){2}\\d+)"],
       "packageNameTemplate": "yarnpkg/yarn",
       "datasourceTemplate": "github-tags",
-      "depTypeTemplate": "engines",
+      "depTypeTemplate": "packageManager",
       "extractVersionTemplate": "^v(?<version>.*)$"
     },
     {
@@ -195,7 +199,7 @@
         "https://raw\\.githubusercontent\\.com/(?<depName>[^/]+/[^/]+)/v?(?<currentValue>(\\d+\\.){2}\\d+)"
       ],
       "datasourceTemplate": "github-tags",
-      "depTypeTemplate": "devDependencies",
+      "depTypeTemplate": "config",
       "extractVersionTemplate": "^v?(?<version>.*)$"
     },
     {


### PR DESCRIPTION
The npm manager considers Yarn v2+ to be of type `packageManager` rather than `engines`, so follow that convention for asdf and Yarn v1.

Introduce the new `depType` `config` for the centralized MegaLinter and Renovate configs as well as Yarn plugins. Use the commit scope `config` when bumping these dependencies. The centralized MegaLinter and Renovate configs are both governed by the same dependency, namely this repository itself, so using different types resulted in a duplicate row in the pull request descriptions generated by Renovate.