### PR TITLE
fix(Renovate): Get Yarn v1 from npm, not GitHub

### DIFF
--- a/default.json
+++ b/default.json
@@ -147,8 +147,8 @@
       "customType": "regex",
       "fileMatch": ["^\\.tool-versions$"],
       "matchStrings": ["(?<depName>yarn)\\s+(?<currentValue>(\\d+\\.){2}\\d+)"],
-      "packageNameTemplate": "yarnpkg/yarn",
-      "datasourceTemplate": "github-tags",
+      "packageNameTemplate": "yarn",
+      "datasourceTemplate": "npm",
       "depTypeTemplate": "packageManager",
       "extractVersionTemplate": "^v(?<version>.*)$"
     },


### PR DESCRIPTION
In the custom manager that bumps Yarn v1 in the MegaLinter config, use the same datasource that we do for Yarn v2+ for consistency, namely npm.