### PR TITLE
style(Renovate): Remove Yarn `packageNameTemplate`

### DIFF
--- a/default.json
+++ b/default.json
@@ -147,7 +147,6 @@
       "customType": "regex",
       "fileMatch": ["^\\.tool-versions$"],
       "matchStrings": ["(?<depName>yarn)\\s+(?<currentValue>(\\d+\\.){2}\\d+)"],
-      "packageNameTemplate": "yarn",
       "datasourceTemplate": "npm",
       "depTypeTemplate": "packageManager",
       "extractVersionTemplate": "^v(?<version>.*)$"


### PR DESCRIPTION
Regex managers use the captured `depName`, in this case `yarn`, from the match string when no package name is specified. Hence, there is no need to specify explicitly that the package name is `yarn`.