### PR TITLE
fix(Renovate): Correct .NET SDK dependency type

### DIFF
--- a/default.json
+++ b/default.json
@@ -159,7 +159,7 @@
       ],
       "packageNameTemplate": "dotnet/sdk",
       "datasourceTemplate": "github-tags",
-      "depTypeTemplate": "engines",
+      "depTypeTemplate": "devDependencies",
       "extractVersionTemplate": "^v(?<version>.*)$"
     },
     {


### PR DESCRIPTION
Change its `depType` from `engines` to `devDependencies`.