### PR TITLE
refactor(Renovate): Migrate to `matchFileNames`

### DIFF
--- a/default.json
+++ b/default.json
@@ -47,7 +47,7 @@
       "semanticCommitScope": "pkg-manager"
     },
     {
-      "matchFiles": ["action.yaml"],
+      "matchFileNames": ["action.yaml"],
       "semanticCommitType": "fix"
     },
     {


### PR DESCRIPTION
`matchFiles` was replaced with `matchFileNames` in Renovate v36.0.0.