### PR TITLE
fix(Renovate): Remove a `depName` from package match

### DIFF
--- a/default.json
+++ b/default.json
@@ -62,7 +62,6 @@
       "matchPackageNames": [
         "bandit",
         "black",
-        "MegaLinter",
         "mega-linter-runner",
         "mypy",
         "prettier",


### PR DESCRIPTION
In Renovate v36.0.0, `matchPackageNames` began matching `packageName` to offer more intuitive behavior. It continues to match `depName` for backwards compatibility, but this behavior is deprecated. In our package rule that groups MegaLinter-related bumps, we already match package names beginning with `"oxsecurity/megalinter"`. Hence, there is no need to match `"MegaLinter"`, the `depName` of the MegaLinter Docker images.