### PR TITLE
fix(Renovate): Prefer GitHub releases to tags

### DIFF
--- a/default.json
+++ b/default.json
@@ -95,7 +95,7 @@
       "matchStrings": [
         "github>(?<depName>ScribeMD/\\.github)#(?<currentValue>(\\d+\\.){2}\\d+)"
       ],
-      "datasourceTemplate": "github-tags",
+      "datasourceTemplate": "github-releases",
       "depTypeTemplate": "config"
     },
     {
@@ -105,7 +105,7 @@
         "runs-on:\\s*['\"]?(?<depName>ubuntu)-(?<currentValue>\\d+)\\.04"
       ],
       "packageNameTemplate": "actions/runner-images",
-      "datasourceTemplate": "github-tags",
+      "datasourceTemplate": "github-releases",
       "depTypeTemplate": "engines",
       "extractVersionTemplate": "^ubuntu(?<version>\\d+)\\/"
     },
@@ -116,7 +116,7 @@
         "runs-on:\\s*['\"]?(?<depName>windows)-\\d+(?<currentValue>\\d{2})"
       ],
       "packageNameTemplate": "actions/runner-images",
-      "datasourceTemplate": "github-tags",
+      "datasourceTemplate": "github-releases",
       "depTypeTemplate": "engines",
       "extractVersionTemplate": "^win(?<version>\\d+)\\/"
     },
@@ -127,7 +127,7 @@
         "(?<depName>asdf)(-|_branch:\\s*)v(?<currentValue>(\\d+\\.){2}\\d+)"
       ],
       "packageNameTemplate": "asdf-vm/asdf",
-      "datasourceTemplate": "github-tags",
+      "datasourceTemplate": "github-releases",
       "depTypeTemplate": "packageManager",
       "extractVersionTemplate": "^v(?<version>.*)$"
     },
@@ -157,7 +157,7 @@
         "(?<depName>dotnet-core)\\s+(?<currentValue>(\\d+\\.){2}\\d+)"
       ],
       "packageNameTemplate": "dotnet/sdk",
-      "datasourceTemplate": "github-tags",
+      "datasourceTemplate": "github-releases",
       "depTypeTemplate": "devDependencies",
       "extractVersionTemplate": "^v(?<version>.*)$"
     },
@@ -196,7 +196,7 @@
       "matchStrings": [
         "https://raw\\.githubusercontent\\.com/(?<depName>[^/]+/[^/]+)/v?(?<currentValue>(\\d+\\.){2}\\d+)"
       ],
-      "datasourceTemplate": "github-tags",
+      "datasourceTemplate": "github-{{#if (equals depName 'ScribeMD/.github')}}releases{{else}}tags{{/if}}",
       "depTypeTemplate": "config",
       "extractVersionTemplate": "^v?(?<version>.*)$"
     },


### PR DESCRIPTION
This repository itself, GitHub-hosted runner images, asdf, and the .NET SDK all publish GitHub releases in addition to tags. Use the releases as the datasource so that bumps can't precede the crafting of release notes and to skip versions that are tagged but never released. Some projects signal that a tagged version was bad by not creating a release for them. Continue using GitHub tags to bump the dependencies that don't create GitHub releases, namely Python and the Yarn licenses plugin.