### PR TITLE
fix(Renovate): Remove GitHub runner regex managers

### DIFF
--- a/default.json
+++ b/default.json
@@ -100,28 +100,6 @@
     },
     {
       "customType": "regex",
-      "fileMatch": ["^\\.github\\/workflows\\/[^/]+\\.yaml$"],
-      "matchStrings": [
-        "runs-on:\\s*['\"]?(?<depName>ubuntu)-(?<currentValue>\\d+)\\.04"
-      ],
-      "packageNameTemplate": "actions/runner-images",
-      "datasourceTemplate": "github-releases",
-      "depTypeTemplate": "engines",
-      "extractVersionTemplate": "^ubuntu(?<version>\\d+)\\/"
-    },
-    {
-      "customType": "regex",
-      "fileMatch": ["^\\.github\\/workflows\\/[^/]+\\.yaml$"],
-      "matchStrings": [
-        "runs-on:\\s*['\"]?(?<depName>windows)-\\d+(?<currentValue>\\d{2})"
-      ],
-      "packageNameTemplate": "actions/runner-images",
-      "datasourceTemplate": "github-releases",
-      "depTypeTemplate": "engines",
-      "extractVersionTemplate": "^win(?<version>\\d+)\\/"
-    },
-    {
-      "customType": "regex",
       "fileMatch": ["^action\\.yaml$"],
       "matchStrings": [
         "(?<depName>asdf)(-|_branch:\\s*)v(?<currentValue>(\\d+\\.){2}\\d+)"


### PR DESCRIPTION
Renovate added first-class support for bumping GitHub-hosted runner images in v36.40.0.