### PR TITLE
fix(Renovate): Remove Poetry Python regex manager

### DIFF
--- a/default.json
+++ b/default.json
@@ -111,10 +111,8 @@
     },
     {
       "customType": "regex",
-      "fileMatch": ["^\\.pre-commit-config\\.yaml$", "^pyproject\\.toml$"],
-      "matchStrings": [
-        "(?<depName>python)(\\s*=\\s*\"==)?(?<currentValue>(\\d+\\.){2}\\d+)"
-      ],
+      "fileMatch": ["^\\.pre-commit-config\\.yaml$"],
+      "matchStrings": ["(?<depName>python)(?<currentValue>(\\d+\\.){2}\\d+)"],
       "packageNameTemplate": "python/cpython",
       "datasourceTemplate": "github-tags",
       "depTypeTemplate": "engines",


### PR DESCRIPTION
Renovate added first-class support for bumping the Python version managed by Poetry in v36.95.0.