### PR TITLE
fix(Renovate): Stop pinning Docker image digests

### DIFF
--- a/.dictionary.txt
+++ b/.dictionary.txt
@@ -1,1 +1,2 @@
+Datasources
 Laven

--- a/default.json
+++ b/default.json
@@ -31,6 +31,10 @@
   },
   "packageRules": [
     {
+      "matchDatasources": ["docker"],
+      "pinDigests": false
+    },
+    {
       "matchDepTypes": ["config"],
       "semanticCommitScope": "config"
     },


### PR DESCRIPTION
The GitHub-hosted runner images cache some commonly used Docker images. Pinning these to specific digests would result in cache misses, because the cached image won't always match the pinned digest. We don't currently have any direct dependencies on Docker images that would benefit from having their digests pinned.