### PR TITLE
ci(Lychee): Stop checking link to Stack Overflow

### DIFF
--- a/lychee.toml
+++ b/lychee.toml
@@ -1,3 +1,5 @@
+# See https://github.com/lycheeverse/lychee/issues/1157.
+exclude = ["^https://stackoverflow\\.com"]
 exclude_mail = true
 exclude_path = ["default.json"]
 max_retries = 4


### PR DESCRIPTION
https://stackoverflow.com recently began blocking link checking requests from GitHub Actions due to changes in their Cloudflare configuration.