### PR TITLE
fix(Renovate): Only prepend "v" when missing

### DIFF
--- a/default.json
+++ b/default.json
@@ -12,7 +12,7 @@
   "commitBodyTable": true,
   "commitMessageAction": "Bump",
   "commitMessageExtra": "to {{#if isPinDigest}}{{{newDigestShort}}}{{else}}{{#if isSingleVersion}}{{prettyNewVersion}}{{else}}{{#if newValue}}{{{newValue}}}{{else}}{{{newDigestShort}}}{{/if}}{{/if}}{{/if}}",
-  "commitMessageTopic": "{{depName}} from {{#if isPinDigest}}{{{currentDigestShort}}}{{else}}{{#if isSingleVersion}}v{{currentVersion}}{{else}}{{#if newValue}}{{{currentValue}}}{{else}}{{{currentDigestShort}}}{{/if}}{{/if}}{{/if}}",
+  "commitMessageTopic": "{{depName}} from {{#if isPinDigest}}{{{currentDigestShort}}}{{else}}{{#if isSingleVersion}}{{replace '^(?<version>(\\d+\\.){2}\\d+)' 'v$<version>' currentVersion}}{{else}}{{#if newValue}}{{{currentValue}}}{{else}}{{{currentDigestShort}}}{{/if}}{{/if}}{{/if}}",
   "configWarningReuseIssue": false,
   "dependencyDashboardApproval": true,
   "dependencyDashboardLabels": ["dependencies"],


### PR DESCRIPTION
We prepend "v" to the "from" version number, `currentVersion`, for consistency with the "to" version number, `prettyNewVersion`, because Renovate doesn't expose a `prettyCurrentVersion`. However, an upstream change recently caused `currentVersion` to start with a "v" when bumping Node.js. Hence, only prepend a "v" to a semantic version number that doesn't start with "v."