### PR TITLE
chore(Poetry): Disable package mode

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ build-backend = "poetry.core.masonry.api"
   major_version_zero = true
 
   [tool.poetry]
+  package-mode = false
   name = "GitHub Starter Workflows"
   version = "0.14.16"
   description = "GitHub Actions Starter Workflows and Default Community Health Files"


### PR DESCRIPTION
We only use Poetry for dependency management, not packaging.